### PR TITLE
Authorization 헤더가 없을 경우 핸들링하는 로직 추가

### DIFF
--- a/src/main/java/com/swyp/catsgotogedog/User/controller/UserController.java
+++ b/src/main/java/com/swyp/catsgotogedog/User/controller/UserController.java
@@ -8,7 +8,10 @@ import com.swyp.catsgotogedog.common.util.JwtTokenUtil;
 import com.swyp.catsgotogedog.global.CatsgotogedogApiResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
+@Slf4j
 public class UserController implements UserControllerSwagger{
 
     private final JwtTokenUtil jwt;
@@ -28,7 +32,6 @@ public class UserController implements UserControllerSwagger{
     @PostMapping("/reissue")
     public ResponseEntity<CatsgotogedogApiResponse<?>> reIssue(
             @CookieValue(value = "X-Refresh-Token", required = false) String refresh) {
-
         return ResponseEntity.ok(CatsgotogedogApiResponse.success("재발급 성공",
             new AccessTokenResponse(userService.reIssue(refresh))));
     }
@@ -38,7 +41,15 @@ public class UserController implements UserControllerSwagger{
             @CookieValue("X-Refresh-Token") String refresh) {
 
         userService.logout(refresh);
+        ResponseCookie cookie = ResponseCookie.from(("X-Refresh-Token"), refresh)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(-1)
+            .build();
 
-        return ResponseEntity.ok(CatsgotogedogApiResponse.success("로그아웃 성공", null));
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, cookie.toString())
+            .body(CatsgotogedogApiResponse.success("로그아웃 성공", null));
     }
 }

--- a/src/main/java/com/swyp/catsgotogedog/User/controller/UserControllerSwagger.java
+++ b/src/main/java/com/swyp/catsgotogedog/User/controller/UserControllerSwagger.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
@@ -19,6 +20,7 @@ public interface UserControllerSwagger {
         summary = "액세스 토큰 재발급",
         description = "리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.\n"
 			+ "재발급된 토큰은 body를 통해 반환됩니다."
+            + " Cookie를 통해 Refresh-Token값을 읽어 재발급을 진행합니다."
     )
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"
@@ -27,14 +29,15 @@ public interface UserControllerSwagger {
                     , content = @Content(schema = @Schema(implementation = CatsgotogedogApiResponse.class)))
     })
     ResponseEntity<?> reIssue(
-        @Parameter(description = "리프레시 토큰", required = false)
+        @Parameter(description = "리프레시 토큰", hidden = true)
         String refresh
     );
 
     @Operation(
         summary = "로그아웃",
-        description = "사용자 로그아웃을 처리하고 리프레시 토큰을 제거합니다."
+        description = "사용자 로그아웃을 처리하고 리프레시 토큰을 제거합니다. Cookie를 통해 Refresh-Token값을 읽어 로그아웃 처리를 진행합니다."
     )
+    @SecurityRequirement(name = "bearer-key")
     @ApiResponses({
 		@ApiResponse(responseCode = "200", description = "로그아웃 성공"
                     , content = @Content(schema = @Schema(implementation = CatsgotogedogApiResponse.class))),
@@ -42,7 +45,7 @@ public interface UserControllerSwagger {
                     , content = @Content(schema = @Schema(implementation = CatsgotogedogApiResponse.class)))
     })
     ResponseEntity<CatsgotogedogApiResponse<?>> logout(
-        @Parameter(description = "리프레시 토큰", required = true)
+        @Parameter(description = "리프레시 토큰", hidden = true)
         String refresh
     );
 }

--- a/src/main/java/com/swyp/catsgotogedog/common/config/CatsgotogedogAuthenticationEntryPoint.java
+++ b/src/main/java/com/swyp/catsgotogedog/common/config/CatsgotogedogAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.swyp.catsgotogedog.common.config;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swyp.catsgotogedog.global.CatsgotogedogApiResponse;
+import com.swyp.catsgotogedog.global.exception.ErrorCode;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CatsgotogedogAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType("application/json");
+		CatsgotogedogApiResponse<?> apiResponse = CatsgotogedogApiResponse.fail(ErrorCode.UNAUTHORIZED_ACCESS);
+
+		log.info(authException.getMessage(), ErrorCode.UNAUTHORIZED_ACCESS.getMessage());
+		objectMapper.writeValue(response.getWriter(), apiResponse);
+	}
+}

--- a/src/main/java/com/swyp/catsgotogedog/common/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/catsgotogedog/common/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
@@ -25,6 +26,7 @@ public class SecurityConfig {
 
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final JwtTokenFilter jwtTokenFilter;
+    private final CatsgotogedogAuthenticationEntryPoint catsgotogedogAuthenticationEntryPoint;
 
     @Value("${allowed.origins.url}")
     private String allowedOriginsUrl;
@@ -44,13 +46,16 @@ public class SecurityConfig {
                             "/login**",
                             "/error",
                             "/swagger-ui/**",
-                            "/v3/api-docs/**"
+                            "/v3/api-docs/**",
+                            "/api/user/reissue"
                             // todo : 인증이 필요 없는 API에 대해 추가 작성 필요
                         ).permitAll()
                         .anyRequest().authenticated())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(eh -> eh.authenticationEntryPoint(catsgotogedogAuthenticationEntryPoint))
                 .addFilterBefore(new OAuth2AutoLoginFilter(), OAuth2AuthorizationRequestRedirectFilter.class)
                 .oauth2Login(oauth -> oauth
-                        .loginPage("/login")          // 커스텀 로그인 화면 (없으면 기본 템플릿)
                         .successHandler(oAuth2LoginSuccessHandler))
                 .addFilterBefore(jwtTokenFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/swyp/catsgotogedog/global/config/SwaggerConfig.java
+++ b/src/main/java/com/swyp/catsgotogedog/global/config/SwaggerConfig.java
@@ -4,6 +4,8 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -16,7 +18,7 @@ public class SwaggerConfig {
 		return new OpenAPI()
 			.components(new Components()
 				.addSecuritySchemes("bearer-key", securityScheme()))
-			.info(new Info());
+			.info(info());
 	}
 
 	private Info info() {

--- a/src/main/java/com/swyp/catsgotogedog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swyp/catsgotogedog/global/exception/GlobalExceptionHandler.java
@@ -24,13 +24,13 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CatsgotogedogException.class)
 	protected ResponseEntity<CatsgotogedogApiResponse<Object>> handleCatsgotogedogException(CatsgotogedogException ex) {
-		log.error("CatsgotogedogException : {}", ex.getMessage());
+		log.error("CatsgotogedogException : {}", ex.getMessage(), ex);
 		return createErrorResponse(ex.getErrorCode());
 	}
 
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<CatsgotogedogApiResponse<Object>> handleException(Exception ex) {
-		log.error("Exception : {}", ex.getMessage());
+		log.error("Exception : {}", ex.getMessage(), ex);
 		int errorCode = ErrorCode.INTERNAL_SERVER_ERROR.getCode();
 		CatsgotogedogApiResponse<Object> response = CatsgotogedogApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR);
 		return ResponseEntity
@@ -95,6 +95,15 @@ public class GlobalExceptionHandler {
 		CatsgotogedogApiResponse<Object> response = CatsgotogedogApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED, e.getMethod());
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
+			.body(response);
+	}
+
+	@ExceptionHandler(UnAuthorizedAccessException.class)
+	protected ResponseEntity<CatsgotogedogApiResponse<Object>> handleUnAuthorizedAccessException(UnAuthorizedAccessException  e) {
+		log.error("UnAuthorizedAccessException: {}", e.getMessage(), e);
+		CatsgotogedogApiResponse<Object> response = CatsgotogedogApiResponse.fail(ErrorCode.UNAUTHORIZED_ACCESS);
+		return ResponseEntity
+			.status(HttpStatus.UNAUTHORIZED)
 			.body(response);
 	}
 


### PR DESCRIPTION
정상적인 401 UnAuthroizedAccessException을 반환하도록 수정했습니다
기존에 Auth 관련 헤더가 없을 경우 이를 핸들링하지 못해 500에러가 반환되어 정상적인 처리가 안되는 현상을 수정했습니다.